### PR TITLE
[WIP] fix: android native module name

### DIFF
--- a/PDFView.android.js
+++ b/PDFView.android.js
@@ -32,7 +32,7 @@ PDFView.propTypes = {
     onLoadComplete: PropTypes.func
 };
 
-var PDFCustomView = requireNativeComponent('PDFView', PDFView, {
+var PDFCustomView = requireNativeComponent('RCTPDFViewAndroid', PDFView, {
   nativeOnly: {onChange: true}
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pdf-view",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "A pdf file view component for react native.",
   "main": "index.js",
   "typings": "./index.d.ts",


### PR DESCRIPTION
in android the name of project is [RCTPDFViewAndroid](https://github.com/Multiware-Tecnologia/react-native-pdf-view/blob/master/android/src/main/java/com/keyee/pdfview/PDFViewManager.java#L35)